### PR TITLE
Middleware version upgrade(nginx,nginx_hm,memcache,activemq,logback)

### DIFF
--- a/ansible/group_vars/ap.yml
+++ b/ansible/group_vars/ap.yml
@@ -19,3 +19,4 @@ cache_manager: memcached
 
 tomcat_version: 9.0.10
 commons_daemon_version : 1.1.0
+activemq_version: 5.15.8

--- a/ansible/group_vars/nfs.yml
+++ b/ansible/group_vars/nfs.yml
@@ -2,7 +2,7 @@
 
 tag_ServerType: nfs
 
-memcached_version: 1.4.21
+memcached_version: 1.5.12
 memcached_lock_maxconn: 256
 memcached_cache_maxconn: 256
 
@@ -15,3 +15,5 @@ cache_port: 11212
 # memcached cachesize
 memcached_lock_cachesize: 256
 memcached_cache_cachesize: 256
+
+logback_version: 1.2.3

--- a/ansible/group_vars/web.yml
+++ b/ansible/group_vars/web.yml
@@ -2,5 +2,5 @@
 
 tag_ServerType: web
 
-nginx_version: 1.14.0
-nginx_hm_version: 0.32
+nginx_version: 1.14.2
+nginx_hm_version: 0.33

--- a/ansible/resource/ap/etc/systemd/system/activemq.service
+++ b/ansible/resource/ap/etc/systemd/system/activemq.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=activemq message queue
-After=network.target
+After=network.target elasticsearch.service
 
 [Service]
 PIDFile=/opt/activemq/data/activemq.pid

--- a/ansible/resource/ap/etc/systemd/system/tomcat.service
+++ b/ansible/resource/ap/etc/systemd/system/tomcat.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Apache Tomcat 8
+Description=Apache Tomcat 9
 After=network.target activemq.service
 
 [Service]
@@ -13,6 +13,7 @@ Environment=JRE_HOME=/opt/jre
 Environment=CATALINA_BASE=/opt/tomcat
 Environment=TOMCAT_USER=personium
 
+ExecStartPre=/bin/sleep 60
 ExecStart=/opt/tomcat/bin/daemon.sh --java-home /opt/jdk --catalina-home /opt/tomcat --catalina-base /opt/tomcat --catalina-pid /opt/tomcat/tomcat.pid --tomcat-user personium start
 ExecStop=/opt/tomcat/bin/daemon.sh --java-home /opt/jdk --catalina-home /opt/tomcat --catalina-base /opt/tomcat --catalina-pid /opt/tomcat/tomcat.pid stop
 [Install]

--- a/ansible/resource/nfs/etc/systemd/system/memcached_cache.service
+++ b/ansible/resource/nfs/etc/systemd/system/memcached_cache.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 Type=simple
 EnvironmentFile=-/etc/sysconfig/memcached_cache
-ExecStart=/opt/memcached-1.4.21/bin/memcached -u $USER -p $PORT -m $CACHESIZE -c $MAXCONN $OPTIONS
+ExecStart=/opt/memcached-{{ memcached_version }}/bin/memcached -u $USER -p $PORT -m $CACHESIZE -c $MAXCONN $OPTIONS
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/resource/nfs/etc/systemd/system/memcached_lock.service
+++ b/ansible/resource/nfs/etc/systemd/system/memcached_lock.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 Type=simple
 EnvironmentFile=-/etc/sysconfig/memcached_lock
-ExecStart=/opt/memcached-1.4.21/bin/memcached -u $USER -p $PORT -m $CACHESIZE -c $MAXCONN $OPTIONS
+ExecStart=/opt/memcached-{{ memcached_version }}/bin/memcached -u $USER -p $PORT -m $CACHESIZE -c $MAXCONN $OPTIONS
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/tasks/ap/init_activemq_install.yml
+++ b/ansible/tasks/ap/init_activemq_install.yml
@@ -3,20 +3,20 @@
 - name: Create download directory
   file: "state=directory path=/usr/local/src/activemq owner=root group=root"
 
-- name: Download apache-activemq-5.15.2-bin.tar.gz
-  command: wget -q -O apache-activemq-5.15.2-bin.tar.gz --no-check-certificate http://archive.apache.org/dist/activemq/5.15.2/apache-activemq-5.15.2-bin.tar.gz
+- name: Download apache-activemq-{{ activemq_version }}-bin.tar.gz
+  command: wget -q -O apache-activemq-{{ activemq_version }}-bin.tar.gz --no-check-certificate http://archive.apache.org/dist/activemq/{{ activemq_version }}/apache-activemq-{{ activemq_version }}-bin.tar.gz
   args:
     chdir: /usr/local/src/activemq
-    creates: /usr/local/src/activemq/apache-activemq-5.15.2-bin.tar.gz
+    creates: /usr/local/src/activemq/apache-activemq-{{ activemq_version }}-bin.tar.gz
 
-- name: Expand apache-activemq-5.15.2-bin.tar.gz
-  unarchive: src=/usr/local/src/activemq/apache-activemq-5.15.2-bin.tar.gz dest=/usr/local/src/activemq copy=no
+- name: Expand apache-activemq-{{ activemq_version }}-bin.tar.gz
+  unarchive: src=/usr/local/src/activemq/apache-activemq-{{ activemq_version }}-bin.tar.gz dest=/usr/local/src/activemq copy=no
 
 - name: Deploy activemq
-  command: mv /usr/local/src/activemq/apache-activemq-5.15.2 /opt/apache-activemq-5.15.2 creates="/opt/apache-activemq-5.15.2"
+  command: mv /usr/local/src/activemq/apache-activemq-{{ activemq_version }} /opt/apache-activemq-{{ activemq_version }} creates="/opt/apache-activemq-{{ activemq_version }}"
 
 - name: Create symlink /opt/activemq
-  file: state=link src=/opt/apache-activemq-5.15.2 dest=/opt/activemq owner=root group=root mode=0777
+  file: state=link src=/opt/apache-activemq-{{ activemq_version }} dest=/opt/activemq owner=root group=root mode=0777
 
 - name: Deploy /etc/systemd/system/activemq.service
   copy: src=./resource/ap/etc/systemd/system/activemq.service dest=/etc/systemd/system/activemq.service  owner=root group=root mode=0755

--- a/ansible/tasks/nfs/init_logback.yml
+++ b/ansible/tasks/nfs/init_logback.yml
@@ -1,10 +1,10 @@
 # Copyright FUJITSU LIMITED 2015-2018.
 
 - name: Download logback
-  command: wget -q -O logback-1.0.3.tar.gz --no-check-certificate http://logback.qos.ch/dist/logback-1.0.3.tar.gz
+  command: wget -q -O logback-{{ logback_version }}.tar.gz --no-check-certificate http://logback.qos.ch/dist/logback-{{ logback_version }}.tar.gz
   args:
     chdir: /usr/local/src
-    creates: /usr/local/src/logback-1.0.3.tar.gz
+    creates: /usr/local/src/logback-{{ logback_version }}.tar.gz
 
 - name: Download slf4j
   command: wget -q -O slf4j-1.6.4.tar.gz --no-check-certificate http://www.slf4j.org/dist/slf4j-1.6.4.tar.gz
@@ -19,10 +19,10 @@
   file: path=/personium/logback/log/logback.log state=touch owner=personium group=personium mode=644
 
 - name: Expand logback
-  command: tar xzf /usr/local/src/logback-1.0.3.tar.gz
+  command: tar xzf /usr/local/src/logback-{{ logback_version }}.tar.gz
   args:
     chdir: /opt/logback
-    creates: /opt/logback/logback-1.0.3
+    creates: /opt/logback/logback-{{ logback_version }}
 
 - name: Expand slf4j
   command: tar xzf /usr/local/src/slf4j-1.6.4.tar.gz
@@ -30,8 +30,8 @@
     chdir: /opt/logback
     creates: /opt/logback/slf4j-1.6.4
 
-- name: Change owner /opt/logback/logback-1.0.3 directory
-  file: state=directory path=/opt/logback/logback-1.0.3 owner=personium group=personium recurse=yes
+- name: Change owner /opt/logback/logback-{{ logback_version }} directory
+  file: state=directory path=/opt/logback/logback-{{ logback_version }} owner=personium group=personium recurse=yes
 
 - name: Change owner /opt/logback/slf4j-1.6.4 directory
   file: state=directory path=/opt/logback/slf4j-1.6.4 owner=personium group=personium recurse=yes


### PR DESCRIPTION
Middleware version upgrade
- nginx:1.14.0->1.14.2
- nginx_hm：0.32->0.33
- memcached：1.4.21->1.5.12
- activeMQ：5.15.2->5.15.8
- logback：1.0.3->1.2.3

Change tomcat start timing
Wait for Elasticsearch 6 to launch